### PR TITLE
Host-switch mode update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Major changes
 
 * Added mutualism boolean for simulation
+* Switch `hs_mode` from a boolean to a string. Can now use `switch`, `spread`, or `both`.
 
 
 ## Bug fixes

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -149,7 +149,7 @@ sim_ltBD <- function(species_tree, gbr, gdr, lgtr, num_loci, transfer_type = "ra
 #' @param time_to_sim time units to simulate until
 #' @param numbsim number of replicates
 #' @param host_limit Maximum number of hosts for symbionts (0 implies no limit)
-#' @param hs_mode Boolean turning host expansion into host switching (explained above) (default = FALSE)
+#' @param hs_mode String allowing these options: host-switching ('switch'), host-spreading ('spread'), or both ('both'), default = 'spread'
 #' @return A list containing the `host_tree`, the `symbiont_tree`, the
 #'     association matrix in the present, with hosts as rows and symbionts as columns, and the history of events that have
 #'     occurred.
@@ -175,7 +175,7 @@ sim_ltBD <- function(species_tree, gbr, gdr, lgtr, num_loci, transfer_type = "ra
 #'                            numbsim = numb_replicates,
 #'                            time_to_sim = time)
 #'
-sim_cophyBD_ana <- function(hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit = 0L, hs_mode = FALSE) {
+sim_cophyBD_ana <- function(hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit = 0L, hs_mode = "spread") {
     .Call(`_treeducken_sim_cophyBD_ana`, hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode)
 }
 
@@ -208,8 +208,7 @@ sim_cophyBD_ana <- function(hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rat
 #' @param time_to_sim time units to simulate until
 #' @param numbsim number of replicates
 #' @param host_limit Maximum number of hosts for symbionts (0 implies no limit)
-#' @param hs_mode Boolean turning host expansion into host switching (explained above) (default = FALSE)
-#' @param mutualism Boolean turning on/off mutualism mode (in mutualism mode hosts are required to have symbionts)
+#' @param hs_mode String allowing these options: host-switching ('switch'), host-spreading ('spread'), or both ('both'), default = 'spread'//' @param mutualism Boolean turning on/off mutualism mode (in mutualism mode hosts are required to have symbionts)
 #' @return A list containing the `host_tree`, the `symbiont_tree`, the
 #'     association matrix in the present, with hosts as rows and symbionts as columns, and the history of events that have
 #'     occurred.
@@ -233,7 +232,7 @@ sim_cophyBD_ana <- function(hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rat
 #'                            numbsim = numb_replicates,
 #'                            time_to_sim = time)
 #'
-sim_cophyBD <- function(hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit = 0L, hs_mode = FALSE, mutualism = FALSE) {
+sim_cophyBD <- function(hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit = 0L, hs_mode = "spread", mutualism = FALSE) {
     .Call(`_treeducken_sim_cophyBD`, hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode, mutualism)
 }
 

--- a/src/Cophylo.cpp
+++ b/src/Cophylo.cpp
@@ -14,7 +14,7 @@ Rcpp::List sim_host_symb_treepair_ana(double hostbr,
                                       double timeToSimTo,
                                       int host_limit,
                                       int numbsim,
-                                      bool hsMode) {
+                                      std::string hsMode) {
     double rho = 1.0;
     Rcpp::List multiphy;
     Rcpp::List hostSymbPair;
@@ -78,7 +78,7 @@ Rcpp::List sim_host_symb_treepair(double hostbr,
                                   double timeToSimTo,
                                   int host_limit,
                                   int numbsim,
-                                  bool hsMode,
+                                  std::string hsMode,
                                   bool mutualism){
 
     double rho = 1.0;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -52,7 +52,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // sim_cophyBD_ana
-Rcpp::List sim_cophyBD_ana(SEXP hbr, SEXP hdr, SEXP sbr, SEXP sdr, SEXP s_disp_r, SEXP s_extp_r, SEXP host_exp_rate, SEXP cosp_rate, SEXP time_to_sim, SEXP numbsim, Rcpp::NumericVector host_limit, Rcpp::LogicalVector hs_mode);
+Rcpp::List sim_cophyBD_ana(SEXP hbr, SEXP hdr, SEXP sbr, SEXP sdr, SEXP s_disp_r, SEXP s_extp_r, SEXP host_exp_rate, SEXP cosp_rate, SEXP time_to_sim, SEXP numbsim, Rcpp::NumericVector host_limit, Rcpp::CharacterVector hs_mode);
 RcppExport SEXP _treeducken_sim_cophyBD_ana(SEXP hbrSEXP, SEXP hdrSEXP, SEXP sbrSEXP, SEXP sdrSEXP, SEXP s_disp_rSEXP, SEXP s_extp_rSEXP, SEXP host_exp_rateSEXP, SEXP cosp_rateSEXP, SEXP time_to_simSEXP, SEXP numbsimSEXP, SEXP host_limitSEXP, SEXP hs_modeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -68,13 +68,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type time_to_sim(time_to_simSEXP);
     Rcpp::traits::input_parameter< SEXP >::type numbsim(numbsimSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type host_limit(host_limitSEXP);
-    Rcpp::traits::input_parameter< Rcpp::LogicalVector >::type hs_mode(hs_modeSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type hs_mode(hs_modeSEXP);
     rcpp_result_gen = Rcpp::wrap(sim_cophyBD_ana(hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode));
     return rcpp_result_gen;
 END_RCPP
 }
 // sim_cophyBD
-Rcpp::List sim_cophyBD(SEXP hbr, SEXP hdr, SEXP sbr, SEXP sdr, SEXP host_exp_rate, SEXP cosp_rate, SEXP time_to_sim, SEXP numbsim, Rcpp::NumericVector host_limit, Rcpp::LogicalVector hs_mode, Rcpp::LogicalVector mutualism);
+Rcpp::List sim_cophyBD(SEXP hbr, SEXP hdr, SEXP sbr, SEXP sdr, SEXP host_exp_rate, SEXP cosp_rate, SEXP time_to_sim, SEXP numbsim, Rcpp::NumericVector host_limit, Rcpp::CharacterVector hs_mode, Rcpp::LogicalVector mutualism);
 RcppExport SEXP _treeducken_sim_cophyBD(SEXP hbrSEXP, SEXP hdrSEXP, SEXP sbrSEXP, SEXP sdrSEXP, SEXP host_exp_rateSEXP, SEXP cosp_rateSEXP, SEXP time_to_simSEXP, SEXP numbsimSEXP, SEXP host_limitSEXP, SEXP hs_modeSEXP, SEXP mutualismSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -88,7 +88,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type time_to_sim(time_to_simSEXP);
     Rcpp::traits::input_parameter< SEXP >::type numbsim(numbsimSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type host_limit(host_limitSEXP);
-    Rcpp::traits::input_parameter< Rcpp::LogicalVector >::type hs_mode(hs_modeSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type hs_mode(hs_modeSEXP);
     Rcpp::traits::input_parameter< Rcpp::LogicalVector >::type mutualism(mutualismSEXP);
     rcpp_result_gen = Rcpp::wrap(sim_cophyBD(hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode, mutualism));
     return rcpp_result_gen;

--- a/src/Simulator.h
+++ b/src/Simulator.h
@@ -21,7 +21,7 @@ class Simulator
         unsigned    indPerPop;
         double      popSize;
         double      generationTime;
-        bool        host_switch_mode;
+        std::string host_switch_mode;
         bool        mutualism;
         std::vector<std::shared_ptr<SpeciesTree>>   gsaTrees;
         std::shared_ptr<SpeciesTree>    spTree;
@@ -129,7 +129,7 @@ class Simulator
                             double cosprate,
                             double timeToSimTo,
                             int host_limit,
-                            bool hsMode,
+                            std::string hsMode,
                             bool mutualism): 
                                 hostBirthRate(hostbr),
                                 hostDeathRate(hostdr),
@@ -149,7 +149,7 @@ class Simulator
             double cospeciationRate;
             double timeToSimTo;
             unsigned hostLimit;
-            bool hsMode;
+            std::string hsMode;
             bool mutualism;
         };
         struct CophySimAna {
@@ -162,7 +162,7 @@ class Simulator
                                 double cosprate,
                                 double timeToSimTo,
                                 int host_limit,
-                                bool hsMode,
+                                std::string hsMode,
                                 double symbdispersal,
                                 double symbextirpation): 
                                     hostBirthRate(hostbr),
@@ -184,7 +184,7 @@ class Simulator
             double cospeciationRate;
             double timeToSimTo;
             unsigned hostLimit;
-            bool hsMode;
+            std::string hsMode;
             double symbDispRate;
             double symbExtRate;
                         
@@ -306,7 +306,7 @@ extern Rcpp::List sim_host_symb_treepair(double hostbr,
                                          double timeToSimTo,
                                          int host_limit,
                                          int numbsim,
-                                         bool hsMode,
+                                         std::string hsMode,
                                          bool mutualism);
 
 extern Rcpp::List sim_host_symb_treepair_ana(double hostbr,
@@ -320,7 +320,7 @@ extern Rcpp::List sim_host_symb_treepair_ana(double hostbr,
                                             double timeToSimTo,
                                             int host_limit,
                                             int numbsim,
-                                            bool hsMode);
+                                            std::string hsMode);
 
 extern Rcpp::List sim_locus_tree_gene_tree(std::shared_ptr<SpeciesTree> species_tree,
                                            double gbr,

--- a/src/rcpp_treeducken.cpp
+++ b/src/rcpp_treeducken.cpp
@@ -218,7 +218,7 @@ Rcpp::List sim_ltBD(Rcpp::List species_tree,
 //' @param time_to_sim time units to simulate until
 //' @param numbsim number of replicates
 //' @param host_limit Maximum number of hosts for symbionts (0 implies no limit)
-//' @param hs_mode Boolean turning host expansion into host switching (explained above) (default = FALSE)
+//' @param hs_mode String allowing these options: host-switching ('switch'), host-spreading ('spread'), or both ('both'), default = 'spread'
 //' @return A list containing the `host_tree`, the `symbiont_tree`, the
 //'     association matrix in the present, with hosts as rows and symbionts as columns, and the history of events that have
 //'     occurred.
@@ -256,7 +256,7 @@ Rcpp::List sim_cophyBD_ana(SEXP hbr,
                         SEXP time_to_sim,
                         SEXP numbsim,
                         Rcpp::NumericVector host_limit = 0,
-                        Rcpp::LogicalVector hs_mode = false){
+                        Rcpp::CharacterVector hs_mode = "spread"){
 
     double hbr_ = as<double>(hbr);
     double hdr_ = as<double>(hdr);
@@ -269,7 +269,7 @@ Rcpp::List sim_cophyBD_ana(SEXP hbr,
     double timeToSimTo_ = as<double>(time_to_sim);
     int hl_ = as<int>(host_limit);
     int numbsim_ = as<int>(numbsim);
-    bool host_switch_mode_ = as<bool>(hs_mode);
+    std::string host_switch_mode_ = as<std::string>(hs_mode);
 
     RNGScope scope;
     if(hbr_ < 0.0){
@@ -297,6 +297,8 @@ Rcpp::List sim_cophyBD_ana(SEXP hbr,
         stop("symbiont dispersal cannot be negative");
     if(symb_ext_ < 0.0)
         stop("symbiont extirpation cannot be negative");
+    if(host_switch_mode_ != "both" && host_switch_mode_ != "spread" && host_switch_mode_ != "switch")
+        stop("'hs_mode' must be one these options: 'both', 'spread' or 'switch'.");
     return sim_host_symb_treepair_ana(hbr_,
                                   hdr_,
                                   sbr_,
@@ -339,8 +341,7 @@ Rcpp::List sim_cophyBD_ana(SEXP hbr,
 //' @param time_to_sim time units to simulate until
 //' @param numbsim number of replicates
 //' @param host_limit Maximum number of hosts for symbionts (0 implies no limit)
-//' @param hs_mode Boolean turning host expansion into host switching (explained above) (default = FALSE)
-//' @param mutualism Boolean turning on/off mutualism mode (in mutualism mode hosts are required to have symbionts)
+//' @param hs_mode String allowing these options: host-switching ('switch'), host-spreading ('spread'), or both ('both'), default = 'spread'//' @param mutualism Boolean turning on/off mutualism mode (in mutualism mode hosts are required to have symbionts)
 //' @return A list containing the `host_tree`, the `symbiont_tree`, the
 //'     association matrix in the present, with hosts as rows and symbionts as columns, and the history of events that have
 //'     occurred.
@@ -374,7 +375,7 @@ Rcpp::List sim_cophyBD(SEXP hbr,
                     SEXP time_to_sim,
                     SEXP numbsim,
                     Rcpp::NumericVector host_limit = 0,
-                    Rcpp::LogicalVector hs_mode = false,
+                    Rcpp::CharacterVector hs_mode = "spread",
                     Rcpp::LogicalVector mutualism = false){
     double hbr_ = as<double>(hbr);
     double hdr_ = as<double>(hdr);
@@ -385,7 +386,7 @@ Rcpp::List sim_cophyBD(SEXP hbr,
     double host_exp_rate_ = as<double>(host_exp_rate);
     double timeToSimTo_ = as<double>(time_to_sim);
     int numbsim_ = as<int>(numbsim);
-    bool host_switch_mode_ = as<bool>(hs_mode);
+    std::string host_switch_mode_ = as<std::string>(hs_mode);
     bool mutualism_ = as<bool>(mutualism);
     RNGScope scope;
     if(hbr_ < 0.0){
@@ -409,6 +410,8 @@ Rcpp::List sim_cophyBD(SEXP hbr,
         stop("'time_to_sim' must be a positive value or 0.0.");
     if(hl_ < 0)
         stop("'host_limit' must be a positive number or 0 (0 turns off the host limit).");
+    if(host_switch_mode_ != "both" && host_switch_mode_ != "spread" && host_switch_mode_ != "switch")
+        stop("'hs_mode' must be one these options: 'both', 'spread' or 'switch'.");
     return sim_host_symb_treepair(hbr_,
                                   hdr_,
                                   sbr_,


### PR DESCRIPTION
Changed `hs_mode` from a boolean switching between host switching and host spreading to a string that takes these values:

* "switch" - for host switching
* "spread" - for host spreading/expansion
* "both" - both